### PR TITLE
Fix the timeout for system call select() for Linux

### DIFF
--- a/src/lssdpcpp/lssdpcpp.cpp
+++ b/src/lssdpcpp/lssdpcpp.cpp
@@ -1299,7 +1299,6 @@ bool Service::checkForMSearchAndSendResponse(std::chrono::milliseconds timeout)
     FD_SET(_impl->_multicast_socket._socket, &fs);
     struct timeval tv;
     memset(&tv, 0, sizeof(tv));
-    tv.tv_usec = 100 * 1000;   // 100 ms
 
     auto begin_time = std::chrono::system_clock::now();
     bool return_value = true;
@@ -1313,6 +1312,7 @@ bool Service::checkForMSearchAndSendResponse(std::chrono::milliseconds timeout)
         #else
         int used_socket_in_select = _impl->_multicast_socket._socket + 1;
         #endif
+        tv.tv_usec = 100 * 1000;   // 100 ms
         int ret = select(used_socket_in_select, &fs, NULL, NULL, &tv);
         if (ret < 0)
         {
@@ -1559,7 +1559,6 @@ bool ServiceFinder::checkForServices(const std::function<void(const ServiceUpdat
     FD_SET(_impl->_multicast_socket._socket, &fs);
     struct timeval tv;
     memset(&tv, 0, sizeof(tv));
-    tv.tv_usec = 100 * 1000;   // 100 ms
 
     auto begin_time = std::chrono::system_clock::now();
     bool return_value = true;
@@ -1571,6 +1570,7 @@ bool ServiceFinder::checkForServices(const std::function<void(const ServiceUpdat
         #else
         int used_socket_in_select = _impl->_multicast_socket._socket + 1;
         #endif
+        tv.tv_usec = 100 * 1000;   // 100 ms
         int ret = select(used_socket_in_select, &fs, NULL, NULL, &tv);
         if (ret < 0)
         {


### PR DESCRIPTION
Hi, @jeanreP.

The protocol will cause immense high cpu load (95%-100%) on Linux.
The reason is the system call `select()` is implemented differently on Linux. 

Please refer to `man select` on Linux or also here https://man7.org/linux/man-pages/man2/select.2.html:

> On Linux, select() also modifies timeout if the call is interrupted by a signal handler (i.e., the EINTR error return). This is not permitted by POSIX.1.  The Linux pselect() system call has the same behavior, but the glibc wrapper hides this behavior by internally copying the timeout to a local variable and passing that variable to the system call.

After the first call of select. The value of `tv` will be set to 0. It means the every consecutive call of `select` will be non blocking in this loop. The loop will hijack the kernel and keep the CPU near 100%.

Assigning the timeout in loop will fix the problem.