### PR TITLE
Use strcpy_s to satisfy modern compilers

### DIFF
--- a/src/lssdpcpp/lssdpcpp.cpp
+++ b/src/lssdpcpp/lssdpcpp.cpp
@@ -226,13 +226,13 @@ struct LSSDPPacket
         // 1. compare SSDP Method Header: M-SEARCH, NOTIFY, RESPONSE
         size_t i;
         if ((i = strlen(LSSDP_HEADER_MSEARCH)) < data_len && memcmp(data, LSSDP_HEADER_MSEARCH, i) == 0) {
-            strcpy(_method, LSSDP_MSEARCH);
+            strcpy_s(_method, sizeof(_method), LSSDP_MSEARCH);
         }
         else if ((i = strlen(LSSDP_HEADER_NOTIFY)) < data_len && memcmp(data, LSSDP_HEADER_NOTIFY, i) == 0) {
-            strcpy(_method, LSSDP_NOTIFY);
+            strcpy_s(_method, sizeof(_method), LSSDP_NOTIFY);
         }
         else if ((i = strlen(LSSDP_HEADER_RESPONSE)) < data_len && memcmp(data, LSSDP_HEADER_RESPONSE, i) == 0) {
-            strcpy(_method, LSSDP_RESPONSE);
+            strcpy_s(_method, sizeof(_method), LSSDP_RESPONSE);
         }
         else
         {

--- a/src/lssdpcpp/lssdpcpp.cpp
+++ b/src/lssdpcpp/lssdpcpp.cpp
@@ -254,10 +254,7 @@ struct LSSDPPacket
 
     private:
     #ifdef WIN32
-        size_t strncasecmp(const char* src, const char* dest, size_t len)
-        {
-            return _strnicmp(src, dest, len);
-        }
+        #define strncasecmp _strnicmp
     #endif 
 
     bool parse_field_line(const char * data, size_t start, size_t end) {


### PR DESCRIPTION
In this case the src string is a fixed size known to be smaller than _method. However,  to suppress compiler warnings and to protect against the event that code changes make _method smaller or the src string larger strcpy_s can be used.